### PR TITLE
switching position to only be included in OBS

### DIFF
--- a/pyrinex/rinex2.py
+++ b/pyrinex/rinex2.py
@@ -235,6 +235,8 @@ def _scan2(fn: Path, use: Any, verbose: bool=False) -> xarray.Dataset:
 
         data.attrs['filename'] = f.name
         data.attrs['version'] = verRinex
+        if 'APPROX POSITION XYZ' in header.keys():
+            data.attrs['position'] = header['APPROX POSITION XYZ']
 
         return data
 


### PR DESCRIPTION
This change adds receiver position to the attributes stored in an observation dataframe.