### PR TITLE
Fix irregular NAV3 file reading for receivers that save only 2 spare …

### DIFF
--- a/georinex/nav3.py
+++ b/georinex/nav3.py
@@ -165,6 +165,8 @@ def _sparefields(cf: List[str], sys: str, raw: str) -> List[str]:
     elif sys == 'E':
         if numval == 28:
             cf = cf[:-3]
+        if numval == 29:
+            cf = cf[:-2]
         elif numval == 27:
             cf = cf[:22] + cf[23:-3]
 


### PR DESCRIPTION
RINEX files generated by rtklib 2.4.3beta contain only 2 Spare words. This case is not considered by the irregular file handling from utils.