### PR TITLE
Extract ionospheric correction parameters from NAV files

### DIFF
--- a/georinex/io.py
+++ b/georinex/io.py
@@ -121,3 +121,7 @@ def rinexinfo(f: Union[Path, TextIO]) -> Dict[str, Any]:
         raise ValueError(f'not a known/valid RINEX file.  {e}')
 
     return info
+
+
+def rinex_string_to_float(x: str) -> float:
+    return float(x.replace('D', 'E'))

--- a/georinex/nav2.py
+++ b/georinex/nav2.py
@@ -6,7 +6,7 @@ from typing.io import TextIO
 import xarray
 import numpy as np
 import logging
-from .io import opener, rinexinfo
+from .io import opener, rinexinfo, rinex_string_to_float
 #
 STARTCOL2 = 3  # column where numerical data starts for RINEX 2
 Nl = {'G': 7, 'R': 3, 'E': 7}   # number of additional SV lines
@@ -128,6 +128,15 @@ def rinexnav2(fn: Path,
     nav.attrs['filename'] = fn.name
     nav.attrs['rinextype'] = 'nav'
 
+    if 'ION ALPHA' in header and 'ION BETA' in header:
+        alpha = header['ION ALPHA']
+        alpha = [rinex_string_to_float(alpha[2 + i*12:2 + (i+1)*12])
+                 for i in range(4)]
+        beta = header['ION BETA']
+        beta = [rinex_string_to_float(beta[2 + i*12:2 + (i+1)*12])
+                for i in range(4)]
+        nav.attrs['ionospheric_corr_GPS'] = np.hstack((alpha, beta))
+
     return nav
 
 
@@ -145,8 +154,8 @@ def navheader2(f: TextIO) -> Dict[str, Any]:
     for ln in f:
         if 'END OF HEADER' in ln:
             break
-
-        hdr[ln[60:]] = ln[:60]
+        kind, content = ln[60:].strip(), ln[:60]
+        hdr[kind] = content
 
     return hdr
 

--- a/tests/data/demo.10n
+++ b/tests/data/demo.10n
@@ -4,8 +4,8 @@ EXAMPLE OF A NAVIGATION RINEX FILE                          COMMENT
 THIS FILE IS PART OF THE gLAB TOOL SUITE                    COMMENT             
 FILE PREPARED BY: ADRIA ROVIRA GARCIA                       COMMENT             
 PLEASE EMAIL ANY COMMENT OR REQUEST TO:   glab @ gage.es    COMMENT             
-     0.1676D-07     0.2235D-07    -0.1192D-07    -0.1192D-07ION ALPHA           
-     0.1208D+06     0.1310D+06    -0.1310D+06    -0.1966D+06ION BETA            
+    0.1676D-07  0.2235D-07 -0.1192D-07 -0.1192D-07          ION ALPHA
+    0.1208D+06  0.1310D+06 -0.1310D+06 -0.1966D+06          ION BETA
    0.133179128170D-06   0.107469588780D-12   552960     1025DELTA-UTC: A0,A1,T,W
     15                                                      LEAP SECONDS        
                                                             END OF HEADER       

--- a/tests/data/galileo3.15n
+++ b/tests/data/galileo3.15n
@@ -1,6 +1,6 @@
      3.03           N: GNSS NAV DATA    E: GALILEO NAV DATA RINEX VERSION / TYPE
 NetR9 5.01          Receiver Operator   20150619 000000 UTC PGM / RUN BY / DATE
-GAL    .1248D+03    .5039D+00    .2377D-01   .0000D+00      IONOSPHERIC CORR
+GAL     .1248D+03   .5039D+00   .2377D-01   .0000D+00       IONOSPHERIC CORR
 GAUT   .3725290298D-08  .532907052D-14 345600 1849          TIME SYSTEM CORR
     16    17  1851    3                                     LEAP SECONDS
                                                             END OF HEADER

--- a/tests/test_nav2.py
+++ b/tests/test_nav2.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import pytest
 from pytest import approx
+from numpy.testing import assert_allclose
 import xarray
 from pathlib import Path
 from datetime import datetime
@@ -152,6 +153,13 @@ def test_small():
     nav = gr.load(R/'demo.10n')
 
     assert nav.equals(truth)
+
+
+def test_ionospheric_correction():
+    nav = gr.load(R/"14601736.18n")
+    assert_allclose(nav.attrs['ionospheric_corr_GPS'],
+                    [0.4657e-08,  0.1490e-07, -0.5960e-07, -0.1192e-06,
+                     0.8192e+05,  0.9830e+05, -0.6554e+05, -0.5243e+06])
 
 
 if __name__ == '__main__':

--- a/tests/test_nav3.py
+++ b/tests/test_nav3.py
@@ -2,6 +2,7 @@
 from pathlib import Path
 import georinex as gr
 import pytest
+from numpy.testing import assert_allclose
 import xarray
 import tempfile
 from datetime import datetime
@@ -218,6 +219,17 @@ def test_galileo():
     nav = gr.load(R/'galileo3.15n')
 
     assert nav.equals(truth)
+
+
+def test_ionospheric_correction():
+    nav = gr.load(R/"demo.17n")
+    assert_allclose(nav.attrs['ionospheric_corr_GPS'],
+                    [1.1176e-08, -1.4901e-08, -5.9605e-08, 1.1921e-07,
+                     9.8304e04, -1.1469e05, -1.9661e05, 7.2090e05])
+
+    nav = gr.load(R/"galileo3.15n")
+    assert_allclose(nav.attrs['ionospheric_corr_GAL'],
+                    [0.1248e+03, 0.5039, 0.2377e-01, 0])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi!

First of all, thank you for creating this package. I'm learning GNSS signal processing and use your package to read RINEX files. 

Now I'm investigating broadcaset ionospheric delay compensation models, so I decided to include model coefficients in the returned data:

Several notes:

1. Model coefficeints are stored in  `attrs` as numpy arrays with 8 or 4 (for Galieo) coefficients.
2. I put `rinex_string_to_float` into `io`, because putting it into `utils` creates a cyclic import. I guess conceptually `utils` should not import other modules.
3. I had to modify "galileo3.15n" file. I assume you created it by hand. If I understand RINEX correctly --- the right way to parse it is to strictly follow Fortran format specifies. So "IONOSPHERIC CORR" line as provided seems to violate it. *Edited*: I had to do the same with `demo.10n`.

Do I miss something in RINEX format specification? Specifically for `ION ALPHA` it reads `2X,4D12.4`, so I convert substring of length 12 asfter skipping first 2 symbols. Or am I theoreticall right, however this strict following is impractical (i.e. every second RINEX file won't conform to it)?

