### PR TITLE
Several fixes

### DIFF
--- a/georinex/io.py
+++ b/georinex/io.py
@@ -105,16 +105,24 @@ def rinexinfo(f: Union[Path, TextIO]) -> Dict[str, Any]:
         if not isinstance(line, str) or line[60:80] not in ('RINEX VERSION / TYPE', 'CRINEX VERS   / TYPE'):
             raise ValueError
 
-        info = {'version': float(line[:9]),  # yes :9
-                'filetype': line[20],
-                'systems': line[40],
-                'hatanaka': line[20:40] == 'COMPACT RINEX FORMAT'}
-
-        if info['systems'] == ' ':
-            if info['filetype'] == 'N' and int(info['version']) == 2:  # type: ignore
-                info['systems'] = 'G'
+        version = float(line[:9])
+        file_type = line[20]
+        if int(version) == 2:
+            if file_type == 'N':
+                system = 'G'
+            elif file_type == 'G':
+                system = 'R'
+            elif file_type == 'E':
+                system = 'E'
             else:
-                info['systems'] = info['filetype']
+                system = line[40]
+        else:
+            system = line[40]
+
+        info = {'version': version,
+                'filetype': file_type,
+                'systems': system,
+                'hatanaka': line[20:40] == 'COMPACT RINEX FORMAT'}
 
     except (ValueError, UnicodeDecodeError) as e:
         # keep ValueError for consistent user error handling

--- a/georinex/nav2.py
+++ b/georinex/nav2.py
@@ -124,6 +124,13 @@ def rinexnav2(fn: Path,
         if k is None:
             continue
         nav[k] = (('time', 'sv'), data[i, :, :])
+
+    # GLONASS uses kilometers to report its ephemeris.
+    # Convert to meters here to be consistent with NAV3 implementation.
+    if svtype == 'R':
+        for name in ['X', 'Y', 'Z', 'dX', 'dY', 'dZ', 'dX2', 'dY2', 'dZ2']:
+            nav[name] *= 1e3
+
 # %% other attributes
     nav.attrs['version'] = header['version']
     nav.attrs['filename'] = fn.name

--- a/georinex/utils.py
+++ b/georinex/utils.py
@@ -104,9 +104,9 @@ def rinextype(fn: Path) -> str:
     else:
         fnl = fn.name.lower()
 
-    if fnl.endswith(('o', 'o.rnx', 'o.crx')):
+    if fnl.endswith(('obs', 'o', 'o.rnx', 'o.crx')):
         return 'obs'
-    elif fnl.endswith(('e', 'g', 'n', 'n.rnx')):
+    elif fnl.endswith(('nav', 'e', 'g', 'n', 'n.rnx')):
         return 'nav'
     elif fn.suffix.endswith('.nc'):
         return 'nc'

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,6 @@ io =
   psutil
 
 [tool:pytest]
-minversion = 3.9
 filterwarnings =
   ignore::DeprecationWarning
 


### PR DESCRIPTION
Hi, guys!

These fixed are not very related to each other, but since they are small I think you woulnd't mind that I put them into a single pull request.

The changes are:

1. Make GNSS type determination for NAV2 files consistent with NAV3 (see the code).
2. Convert kilometers for meters for GLONASS ephemeris in NAV2 as well.
3. Condier '.obs' and '.nav' as a valid extension. These are the extensions that RTKLib will use when converting from proprietary protocols, so I think it makes sense to include them as well.