### PR TITLE
Change maximum number of SV ids to 36 (Galileo has E36)

### DIFF
--- a/georinex/obs2.py
+++ b/georinex/obs2.py
@@ -86,7 +86,7 @@ def rinexsystem2(fn: Union[TextIO, Path],
 # %% allocation
     # these values are not perfect, but seem reasonable.
     # Let us know if you needed to change them.
-    Nsvsys = 35  # Beidou is 35 max, the current maximum GNSS SV count
+    Nsvsys = 36  # Galileo has SV ids up to 36
 
     hdr = obsheader2(fn, useindicators, meas)
 


### PR DESCRIPTION
Hi!

This is a tiny change increasing maximum number of SV ids to 36 for RINEX 2 obs files. Before the change I had errors with E36 presenting in the observations. I haven't analyzed it too much, but it seems to be a correct change.