### PR TITLE
Derive interval attribute from data if missing

### DIFF
--- a/georinex/obs2.py
+++ b/georinex/obs2.py
@@ -266,9 +266,11 @@ def rinexsystem2(fn: Union[TextIO, Path],
     # Get interval from header or derive it from the data
     if 'interval' in hdr.keys():
         data.attrs['interval'] = hdr['interval']
-    else:
+    elif 'time' in data.coords.keys():
         # median is robust against gaps
         data.attrs['interval'] = np.median(np.diff(data.time)/np.timedelta64(1, 's'))
+    else:
+        data.attrs['interval'] = np.nan
 
     obs.attrs['rinextype'] = 'obs'
     obs.attrs['fast_processing'] = int(fast)  # bool is not allowed in NetCDF4

--- a/georinex/obs2.py
+++ b/georinex/obs2.py
@@ -262,22 +262,26 @@ def rinexsystem2(fn: Union[TextIO, Path],
     obs = obs.dropna(dim='time', how='all')  # when tlim specified
 # %% attributes
     obs.attrs['version'] = hdr['version']
-    try:
-        obs.attrs['interval'] = hdr['interval']
-    except KeyError:
-        pass
+    
+    # Get interval from header or derive it from the data
+    if 'interval' in hdr.keys():
+        data.attrs['interval'] = hdr['interval']
+    else:
+        # median is robust against gaps
+        data.attrs['interval'] = np.median(np.diff(data.time)/np.timedelta64(1, 's'))
+        
     obs.attrs['rinextype'] = 'obs'
     obs.attrs['fast_processing'] = int(fast)  # bool is not allowed in NetCDF4
     obs.attrs['time_system'] = determine_time_system(hdr)
     if isinstance(fn, Path):
         obs.attrs['filename'] = fn.name
 
-    try:
+    if 'position' in hdr.keys():
         obs.attrs['position'] = hdr['position']
+        
+    if 'position_geodetic' in hdr.keys():
         obs.attrs['position_geodetic'] = hdr['position_geodetic']
-    except KeyError:
-        pass
-
+        
     return obs
 
 

--- a/georinex/obs2.py
+++ b/georinex/obs2.py
@@ -268,7 +268,7 @@ def rinexsystem2(fn: Union[TextIO, Path],
         obs.attrs['interval'] = hdr['interval']
     elif 'time' in obs.coords.keys():
         # median is robust against gaps
-        obs.attrs['interval'] = np.median(np.diff(data.time)/np.timedelta64(1, 's'))
+        obs.attrs['interval'] = np.median(np.diff(obs.time)/np.timedelta64(1, 's'))
     else:
         obs.attrs['interval'] = np.nan
 

--- a/georinex/obs2.py
+++ b/georinex/obs2.py
@@ -265,12 +265,12 @@ def rinexsystem2(fn: Union[TextIO, Path],
 
     # Get interval from header or derive it from the data
     if 'interval' in hdr.keys():
-        data.attrs['interval'] = hdr['interval']
-    elif 'time' in data.coords.keys():
+        obs.attrs['interval'] = hdr['interval']
+    elif 'time' in obs.coords.keys():
         # median is robust against gaps
-        data.attrs['interval'] = np.median(np.diff(data.time)/np.timedelta64(1, 's'))
+        obs.attrs['interval'] = np.median(np.diff(data.time)/np.timedelta64(1, 's'))
     else:
-        data.attrs['interval'] = np.nan
+        obs.attrs['interval'] = np.nan
 
     obs.attrs['rinextype'] = 'obs'
     obs.attrs['fast_processing'] = int(fast)  # bool is not allowed in NetCDF4

--- a/georinex/obs2.py
+++ b/georinex/obs2.py
@@ -268,7 +268,10 @@ def rinexsystem2(fn: Union[TextIO, Path],
         obs.attrs['interval'] = hdr['interval']
     elif 'time' in obs.coords.keys():
         # median is robust against gaps
-        obs.attrs['interval'] = np.median(np.diff(obs.time)/np.timedelta64(1, 's'))
+        try:
+            obs.attrs['interval'] = np.median(np.diff(obs.time)/np.timedelta64(1, 's'))
+        except TypeError:
+            pass
     else:
         obs.attrs['interval'] = np.nan
 

--- a/georinex/obs2.py
+++ b/georinex/obs2.py
@@ -262,14 +262,14 @@ def rinexsystem2(fn: Union[TextIO, Path],
     obs = obs.dropna(dim='time', how='all')  # when tlim specified
 # %% attributes
     obs.attrs['version'] = hdr['version']
-    
+
     # Get interval from header or derive it from the data
     if 'interval' in hdr.keys():
         data.attrs['interval'] = hdr['interval']
     else:
         # median is robust against gaps
         data.attrs['interval'] = np.median(np.diff(data.time)/np.timedelta64(1, 's'))
-        
+
     obs.attrs['rinextype'] = 'obs'
     obs.attrs['fast_processing'] = int(fast)  # bool is not allowed in NetCDF4
     obs.attrs['time_system'] = determine_time_system(hdr)
@@ -278,10 +278,10 @@ def rinexsystem2(fn: Union[TextIO, Path],
 
     if 'position' in hdr.keys():
         obs.attrs['position'] = hdr['position']
-        
+
     if 'position_geodetic' in hdr.keys():
         obs.attrs['position_geodetic'] = hdr['position_geodetic']
-        
+
     return obs
 
 

--- a/georinex/obs3.py
+++ b/georinex/obs3.py
@@ -125,7 +125,10 @@ def rinexobs3(fn: Union[TextIO, str, Path],
         data.attrs['interval'] = hdr['interval']
     elif 'time' in data.coords.keys():
         # median is robust against gaps
-        data.attrs['interval'] = np.median(np.diff(data.time)/np.timedelta64(1, 's'))
+        try:
+            data.attrs['interval'] = np.median(np.diff(data.time)/np.timedelta64(1, 's'))
+        except TypeError:
+            pass
     else:
         data.attrs['interval'] = np.nan
 

--- a/georinex/obs3.py
+++ b/georinex/obs3.py
@@ -119,14 +119,14 @@ def rinexobs3(fn: Union[TextIO, str, Path],
     data = data.assign_coords(sv=[s.replace(' ', '0') for s in data.sv.values.tolist()])
 # %% other attributes
     data.attrs['version'] = hdr['version']
-    
+
     # Get interval from header or derive it from the data
     if 'interval' in hdr.keys():
         data.attrs['interval'] = hdr['interval']
     else:
         # median is robust against gaps
         data.attrs['interval'] = np.median(np.diff(data.time)/np.timedelta64(1, 's'))
-        
+
     data.attrs['rinextype'] = 'obs'
     data.attrs['fast_processing'] = 0  # bool is not allowed in NetCDF4
     data.attrs['time_system'] = determine_time_system(hdr)

--- a/georinex/obs3.py
+++ b/georinex/obs3.py
@@ -123,9 +123,11 @@ def rinexobs3(fn: Union[TextIO, str, Path],
     # Get interval from header or derive it from the data
     if 'interval' in hdr.keys():
         data.attrs['interval'] = hdr['interval']
-    else:
+    elif 'time' in data.coords.keys():
         # median is robust against gaps
         data.attrs['interval'] = np.median(np.diff(data.time)/np.timedelta64(1, 's'))
+    else:
+        data.attrs['interval'] = np.nan
 
     data.attrs['rinextype'] = 'obs'
     data.attrs['fast_processing'] = 0  # bool is not allowed in NetCDF4

--- a/georinex/obs3.py
+++ b/georinex/obs3.py
@@ -119,22 +119,24 @@ def rinexobs3(fn: Union[TextIO, str, Path],
     data = data.assign_coords(sv=[s.replace(' ', '0') for s in data.sv.values.tolist()])
 # %% other attributes
     data.attrs['version'] = hdr['version']
-    try:
+    
+    # Get interval from header or derive it from the data
+    if 'interval' in hdr.keys():
         data.attrs['interval'] = hdr['interval']
-    except KeyError:
-        pass
+    else:
+        # median is robust against gaps
+        data.attrs['interval'] = np.median(np.diff(data.time)/np.timedelta64(1, 's'))
+        
     data.attrs['rinextype'] = 'obs'
     data.attrs['fast_processing'] = 0  # bool is not allowed in NetCDF4
     data.attrs['time_system'] = determine_time_system(hdr)
     if isinstance(fn, Path):
         data.attrs['filename'] = fn.name
 
-    try:
+    if 'position' in hdr.keys():
         data.attrs['position'] = hdr['position']
         if ecef2geodetic is not None:
             data.attrs['position_geodetic'] = hdr['position_geodetic']
-    except KeyError:
-        pass
 
     # data.attrs['toffset'] = toffset
 


### PR DESCRIPTION
`INTERVAL` is a recommended, yet only optional header field and therefore may be missing as an xarray attribute. My scripts use this value, so I added a logic to derive it from the data. I have never seen a RINEX file with a variable interval length, so I expect this to be robust.

Maybe this is also useful for others.