### PR TITLE
RINEX 3: Fail for out-of-spec lines

### DIFF
--- a/georinex/obs3.py
+++ b/georinex/obs3.py
@@ -152,8 +152,8 @@ def _timeobs(ln: str) -> datetime:
     """
     convert time from RINEX 3 OBS text to datetime
     """
-    if not ln.startswith('>'):  # pg. A13
-        raise ValueError(f'RINEX 3 line beginning > is not present')
+    if not ln.startswith('> '):  # pg. A13
+        raise ValueError(f'RINEX 3 line beginning "> " is not present')
 
     return datetime(int(ln[2:6]), int(ln[7:9]), int(ln[10:12]),
                     hour=int(ln[13:15]), minute=int(ln[16:18]),


### PR DESCRIPTION
Observed in the wild: A RNX file with records starting with just `>`, like `>2019 08 09`.